### PR TITLE
allow developers to set a custom header field for the client authroiz…

### DIFF
--- a/proxy/request_preprocessing.go
+++ b/proxy/request_preprocessing.go
@@ -44,7 +44,7 @@ func (e *preprocessingError) Error() string {
 func requestPreprocessing(w http.ResponseWriter, r *http.Request) error {
 	logger.LogReq(logger.DEBUG, r)
 	sanitizeRequest(r)
-	if !verifyAuthorization(r.Header.Get("Authorization"), r.RemoteAddr) {
+	if !verifyAuthorization(r.Header.Get(ClientAuthorizationField), r.RemoteAddr) {
 		w.WriteHeader(403)
 		return &preprocessingError{-1, "Client Not Authorized"}
 	}

--- a/proxy/request_preprocessing.go
+++ b/proxy/request_preprocessing.go
@@ -14,8 +14,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/acm-uiuc/arbor/logger"
-	"github.com/acm-uiuc/arbor/security"
+	"github.com/arbor-dev/arbor/logger"
+	"github.com/arbor-dev/arbor/security"
 )
 
 func verifyAuthorization(authorization string, remoteAddr string) bool {

--- a/proxy/request_preprocessing.go
+++ b/proxy/request_preprocessing.go
@@ -44,7 +44,7 @@ func (e *preprocessingError) Error() string {
 func requestPreprocessing(w http.ResponseWriter, r *http.Request) error {
 	logger.LogReq(logger.DEBUG, r)
 	sanitizeRequest(r)
-	if !verifyAuthorization(r.Header.Get(ClientAuthorizationField), r.RemoteAddr) {
+	if !verifyAuthorization(r.Header.Get(ClientAuthorizationHeaderField), r.RemoteAddr) {
 		w.WriteHeader(403)
 		return &preprocessingError{-1, "Client Not Authorized"}
 	}

--- a/proxy/settings.go
+++ b/proxy/settings.go
@@ -29,4 +29,4 @@ var Timeout int64 = 10
 var AccessControlPolicy = "*"
 
 // Client Authorization Token Field
-var ClientAuthorizationField = "Authorization"
+var ClientAuthorizationHeaderField = "Authorization"

--- a/proxy/settings.go
+++ b/proxy/settings.go
@@ -27,3 +27,6 @@ var Timeout int64 = 10
 
 // AccessControlPolicy is the default Access control policy
 var AccessControlPolicy = "*"
+
+// Client Authorization Token Field
+var ClientAuthorizationField = "Authorization"

--- a/security/access_log.go
+++ b/security/access_log.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/acm-uiuc/arbor/logger"
+	"github.com/arbor-dev/arbor/logger"
 )
 
 type accessLogger struct {


### PR DESCRIPTION
…ation token

High level overview of changes 

Allows developers to set ```Proxy.ClientAuthorizationField``` to another field if they wish to use Authorization for something else (e.g. Proxy-Authorization) 

- [ ] Make sure to tag the issue you are addressing in your comments if applicable. 
- [X] Make sure any tests pass
- [X] Make sure you stick to rough style guidelines
- [ ] Have you added the license header to any new files? 
- [X] Tag a reviewer 
- [ ] Select target milestone
- [X] Make sure to document any new features or API changes (need to add a settings page to the non-existent documentation site) 
