### PR TITLE
Pass redirect through to client

### DIFF
--- a/proxy/GET.go
+++ b/proxy/GET.go
@@ -63,17 +63,16 @@ func GET(w http.ResponseWriter, url string, format string, token string, r *http
 	}
 	res, err := client.Do(req)
 
-	for k, vs := range res.Header {
-		w.Header()[k] = make([]string, len(vs))
-		copy(w.Header()[k], vs)
-	}
-
 	logger.LogResp(logger.DEBUG, res)
 
 	if err != nil {
 		// Log the error, but return the output from the service.
 		invalidGET(w, err)
 		logger.Log(logger.ERR, err.Error())
+		return
+	} else if res.StatusCode == http.StatusFound {
+		w.Header().Set("Location", res.Header.Get("Location"))
+		w.WriteHeader(http.StatusFound)
 		return
 	} else if res.StatusCode != http.StatusOK {
 		logger.Log(logger.WARN, "SERVICE RETURNED STATUS " + http.StatusText(res.StatusCode))
@@ -115,7 +114,6 @@ func GET(w http.ResponseWriter, url string, format string, token string, r *http
 		textGET(w, url, contents)
 		break
 	}
-
 }
 
 func jsonGET(w http.ResponseWriter, url string, contents []byte) {

--- a/proxy/GET.go
+++ b/proxy/GET.go
@@ -55,8 +55,18 @@ func GET(w http.ResponseWriter, url string, format string, token string, r *http
 		req.Header.Set("Authorization", token)
 	}
 
-	client := &http.Client{Timeout: time.Duration(Timeout) * time.Second}
+	client := &http.Client{
+		Timeout: time.Duration(Timeout) * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 	res, err := client.Do(req)
+
+	for k, vs := range res.Header {
+		w.Header()[k] = make([]string, len(vs))
+		copy(w.Header()[k], vs)
+	}
 
 	logger.LogResp(logger.DEBUG, res)
 

--- a/proxy/GET.go
+++ b/proxy/GET.go
@@ -71,6 +71,7 @@ func GET(w http.ResponseWriter, url string, format string, token string, r *http
 		logger.Log(logger.ERR, err.Error())
 		return
 	} else if res.StatusCode == http.StatusFound {
+		logger.Log(logger.DEBUG, "SERVICE RETURNED REDIRECT")
 		w.Header().Set("Location", res.Header.Get("Location"))
 		w.WriteHeader(http.StatusFound)
 		return

--- a/proxy/GET.go
+++ b/proxy/GET.go
@@ -71,7 +71,7 @@ func GET(w http.ResponseWriter, url string, format string, token string, r *http
 		logger.Log(logger.ERR, err.Error())
 		return
 	} else if res.StatusCode == http.StatusFound {
-		logger.Log(logger.DEBUG, "SERVICE RETURNED REDIRECT")
+		logger.Log(logger.DEBUG, "Service Returned Redirect")
 		w.Header().Set("Location", res.Header.Get("Location"))
 		w.WriteHeader(http.StatusFound)
 		return

--- a/proxy/POST.go
+++ b/proxy/POST.go
@@ -114,7 +114,7 @@ func jsonPOST(r *http.Request, w http.ResponseWriter, url string, token string, 
 		logger.Log(logger.ERR, err.Error())
 		return
 	} else if resp.StatusCode == http.StatusFound {
-		logger.Log(logger.DEBUG, "SERVICE RETURNED REDIRECT")
+		logger.Log(logger.DEBUG, "Service Returned Redirect")
 		w.Header().Set("Location", resp.Header.Get("Location"))
 		w.WriteHeader(http.StatusFound)
 		return
@@ -181,7 +181,7 @@ func xmlPOST(r *http.Request, w http.ResponseWriter, url string, token string, c
 		logger.Log(logger.ERR, err.Error())
 		return
 	} else if resp.StatusCode == http.StatusFound {
-		logger.Log(logger.DEBUG, "SERVICE RETURNED REDIRECT")
+		logger.Log(logger.DEBUG, "Service Returned Redirect")
 		w.Header().Set("Location", resp.Header.Get("Location"))
 		w.WriteHeader(http.StatusFound)
 		return

--- a/proxy/PUT.go
+++ b/proxy/PUT.go
@@ -130,11 +130,11 @@ func jsonPUT(r *http.Request, w http.ResponseWriter, url string, token string, d
 	logger.LogResp(logger.DEBUG, resp)
 
 	if err != nil {
-		//TODO: INVALID PUT HANDLER 
+		invalidPUT(w, err)
 		logger.Log(logger.ERR, err.Error())
 		return
 	} else if resp.StatusCode == http.StatusFound {
-		logger.Log(logger.DEBUG, "SERVICE RETURNED REDIRECT")
+		logger.Log(logger.DEBUG, "Service Returned Redirect")
 		w.Header().Set("Location", resp.Header.Get("Location"))
 		w.WriteHeader(http.StatusFound)
 		return
@@ -194,17 +194,17 @@ func xmlPUT(r *http.Request, w http.ResponseWriter, url string, token string, da
 	logger.LogResp(logger.DEBUG, resp)
 
 	if err != nil {
-		//TODO: INVALID PUT HANDLER 
+		invalidPUT(w, err)
 		logger.Log(logger.ERR, err.Error())
 		return
 	} else if resp.StatusCode == http.StatusFound {
-		logger.Log(logger.DEBUG, "SERVICE RETURNED REDIRECT")
+		logger.Log(logger.DEBUG, "Service Returned Redirect")
 		w.Header().Set("Location", resp.Header.Get("Location"))
 		w.WriteHeader(http.StatusFound)
 		return
 	} else if resp.StatusCode != http.StatusOK {
 		logger.Log(logger.WARN, "SERVICE FAILED - SERVICE RETURNED STATUS "+http.StatusText(resp.StatusCode))
-		w.Header().Set("Content-Type", "<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+		w.Header().Set("Content-Type", XMLHeader)
 		w.WriteHeader(resp.StatusCode)
 		return
 	}


### PR DESCRIPTION
Addresses #45

Instead of following redirects pass them through to the client, so that the client can deal with the redirect as they want.

- [x] Make sure to tag the issue you are addressing in your comments if applicable. 
- [x] Make sure any tests pass
- [x] Make sure you stick to rough style guidelines
- [ ] Have you added the license header to any new files? 
- [ ] Tag a reviewer 
- [ ] Select target milestone
- [ ] Make sure to document any new features or API changes
