### PR TITLE
Set headers before call to write

### DIFF
--- a/proxy/DELETE.go
+++ b/proxy/DELETE.go
@@ -75,13 +75,14 @@ func DELETE(w http.ResponseWriter, url string, format string, token string, r *h
 		return
 	}
 
+	w.Header().Set("Content-Type", JSONHeader)
+
 	if err := json.NewEncoder(w).Encode(serverData); err != nil {
 		invalidDELETE(w, err)
 		logger.Log(logger.ERR, fmt.Sprintf("Failed encode %v", err))
 		return
 	}
 
-	w.Header().Set("Content-Type", JSONHeader)
 	//IF THINGS START BREAKING UNCOMMENT
 	//w.WriteHeader(http.StatusOK)
 }

--- a/proxy/POST.go
+++ b/proxy/POST.go
@@ -131,13 +131,14 @@ func jsonPOST(r *http.Request, w http.ResponseWriter, url string, token string, 
 		return
 	}
 
+	w.Header().Set("Content-Type", JSONHeader)
+
 	if err := json.NewEncoder(w).Encode(serverData); err != nil {
 		invalidPOST(w, err)
 		logger.Log(logger.ERR, err.Error())
 		return
 	}
 
-	w.Header().Set("Content-Type", JSONHeader)
 	//NOTE: Apparently not needed but add back in if things break
 	//w.WriteHeader(http.StatusCreated)
 }
@@ -174,12 +175,13 @@ func xmlPOST(r *http.Request, w http.ResponseWriter, url string, token string, c
 		return
 	}
 
+	w.Header().Set("Content-Type", XMLHeader)
+
 	if err := json.NewEncoder(w).Encode(serverData); err != nil {
 		invalidPOST(w, err)
 		logger.Log(logger.ERR, err.Error())
 		return
 	}
-	w.Header().Set("Content-Type", XMLHeader)
 	w.WriteHeader(http.StatusCreated)
 }
 

--- a/proxy/PUT.go
+++ b/proxy/PUT.go
@@ -145,12 +145,14 @@ func jsonPUT(r *http.Request, w http.ResponseWriter, url string, token string, d
 		return
 	}
 
+	w.Header().Set("Content-Type", JSONHeader)
+
 	if err := json.NewEncoder(w).Encode(serverData); err != nil {
 		invalidPUT(w, err)
 		logger.Log(logger.ERR, fmt.Sprintf("Failed to encode:%v", err))
 		return
 	}
-	w.Header().Set("Content-Type", JSONHeader)
+
 	//ADD BACK IF THINGS START BREAKING
 	//w.WriteHeader(http.StatusOK)
 }
@@ -193,11 +195,13 @@ func xmlPUT(r *http.Request, w http.ResponseWriter, url string, token string, da
 		return
 	}
 
+	w.Header().Set("Content-Type", JSONHeader)
+
 	if err := json.NewEncoder(w).Encode(serverData); err != nil {
 		invalidPUT(w, err)
 		logger.Log(logger.ERR, fmt.Sprintf("Failed encode:%v", err))
 		return
 	}
-	w.Header().Set("Content-Type", JSONHeader)
+
 	w.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
Set `Content-Type` header before call to `json.NewEncoder(w).Encode(serverData)`.

The `Encode` function calls `Write` on the `ResponseWriter`. After this headers in the response are no longer modifyable.

From the [docs](https://golang.org/pkg/net/http/#ResponseWriter):
```
        // Changing the header map after a call to WriteHeader (or
        // Write) has no effect unless the modified headers are
        // trailers.
```

- [ ] Make sure to tag the issue you are addressing in your comments if applicable. 
- [x] Make sure any tests pass
- [x] Make sure you stick to rough style guidelines
- [ ] Have you added the license header to any new files? 
- [ ] Tag a reviewer 
- [ ] Select target milestone
- [ ] Make sure to document any new features or API changes
