### PR TITLE
Add support for raw file upload PUT requests

### DIFF
--- a/proxy/PATCH.go
+++ b/proxy/PATCH.go
@@ -40,7 +40,7 @@ func PATCH(w http.ResponseWriter, url string, format string, token string, r *ht
 		return
 	}
 
-	_, err := ioutil.ReadAll(io.LimitReader(r.Body, 1048576))
+	_, err := ioutil.ReadAll(io.LimitReader(r.Body, MaxRequestSize))
 	if err != nil {
 		invalidPATCH(w, err)
 		logger.Log(logger.ERR, err.Error())

--- a/proxy/POST.go
+++ b/proxy/POST.go
@@ -49,7 +49,7 @@ func POST(w http.ResponseWriter, url string, format string, token string, r *htt
 		logger.Log(logger.ERR, err.Error())
 		return
 	}
-	contents, err := ioutil.ReadAll(io.LimitReader(r.Body, 1048576))
+	contents, err := ioutil.ReadAll(io.LimitReader(r.Body, MaxRequestSize))
 	if err != nil {
 		invalidPOST(w, err)
 		logger.Log(logger.ERR, err.Error())

--- a/proxy/PUT.go
+++ b/proxy/PUT.go
@@ -261,19 +261,13 @@ func rawPUT(r *http.Request, w http.ResponseWriter, url string, token string) {
 		return
 	}
 
-	var serverData interface{}
-	err = json.Unmarshal(contents, &serverData)
+	w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
+
+	_, err = w.Write(contents)
+
 	if err != nil {
 		invalidPUT(w, err)
-		logger.Log(logger.ERR, fmt.Sprintf("Failed to decode:%v", err))
-		return
-	}
-
-	w.Header().Set("Content-Type", JSONHeader)
-
-	if err := json.NewEncoder(w).Encode(serverData); err != nil {
-		invalidPUT(w, err)
-		logger.Log(logger.ERR, fmt.Sprintf("Failed to encode:%v", err))
+		logger.Log(logger.ERR, fmt.Sprintf("Failed to Write:%v", err))
 		return
 	}
 }

--- a/proxy/PUT.go
+++ b/proxy/PUT.go
@@ -54,7 +54,7 @@ func PUT(w http.ResponseWriter, url string, format string, token string, r *http
 		logger.Log(logger.ERR, err.Error())
 		return
 	}
-	content, err := ioutil.ReadAll(io.LimitReader(r.Body, 1048576))
+	content, err := ioutil.ReadAll(io.LimitReader(r.Body, MaxRequestSize))
 	if err != nil {
 		invalidPUT(w, err)
 		logger.Log(logger.ERR, err.Error())
@@ -212,7 +212,7 @@ func xmlPUT(r *http.Request, w http.ResponseWriter, url string, token string, da
 }
 
 func rawPUT(r *http.Request, w http.ResponseWriter, url string, token string) {
-	content, err := ioutil.ReadAll(io.LimitReader(r.Body, 16777216))
+	content, err := ioutil.ReadAll(io.LimitReader(r.Body, MaxFileUploadSize))
 
 	if err != nil {
 		invalidPUT(w, err)

--- a/proxy/settings.go
+++ b/proxy/settings.go
@@ -30,3 +30,10 @@ var AccessControlPolicy = "*"
 
 // Client Authorization Token Field
 var ClientAuthorizationHeaderField = "Authorization"
+
+// Defines the maximum size for requests
+const (
+	MB = 1048576
+	MaxRequestSize = 1 * MB
+	MaxFileUploadSize = 16 * MB
+)

--- a/security/sanitizer.go
+++ b/security/sanitizer.go
@@ -19,11 +19,17 @@ import (
 	"github.com/kennygrant/sanitize"
 )
 
+// Defines the maximum size for sanitized requests
+const (
+	MB = 1048576
+	MaxSize = 16 * MB
+)
+
 func SanitizeRequest(r *http.Request) {
 	if !enabled {
 		return
 	}
-	content, _ := ioutil.ReadAll(io.LimitReader(r.Body, 1048576))
+	content, _ := ioutil.ReadAll(io.LimitReader(r.Body, MaxSize))
 	sanitizedHTML := sanitize.HTML(string(content))
 	r.Body = ioutil.NopCloser(strings.NewReader(sanitizedHTML))
 	r.ContentLength = int64(len(sanitizedHTML))


### PR DESCRIPTION
This PR adds support for file uploads in `PUT` requests. This is done by adding a `rawPUT` handler which forwards the contents of the request body as raw bytes instead of attempting to parse it to `JSON` or `XML`. Requests are sent through this handler if the format `RAW` is specified when registering a route with arbor. Additionally the max upload size is capped at `~16mb` instead of the `~1mb` generally used in arbor.

Requesting a review from @narendasan and @bcongdon.

This PR also addresses #49.

- [x] Make sure to tag the issue you are addressing in your comments if applicable. 
- [x] Make sure any tests pass
- [x] Make sure you stick to rough style guidelines
- [ ] Have you added the license header to any new files? 
- [x] Tag a reviewer 
- [ ] Select target milestone
- [x] Make sure to document any new features or API changes
