### PR TITLE
Sends response body for even non-200 requests

### DIFF
--- a/examples/gateway/gateway.go
+++ b/examples/gateway/gateway.go
@@ -2,11 +2,11 @@ package gateway
 
 import (
 	"fmt"
-	"net/http"
 	"github.com/arbor-dev/arbor"
 	"github.com/arbor-dev/arbor/logger"
 	"github.com/arbor-dev/arbor/proxy"
 	"github.com/arbor-dev/arbor/security"
+	"net/http"
 )
 
 //The Global Collection of Routes, not necessary but good for organization

--- a/proxy/DELETE.go
+++ b/proxy/DELETE.go
@@ -59,7 +59,7 @@ func DELETE(w http.ResponseWriter, url string, format string, token string, r *h
 		logger.Log(logger.ERR, fmt.Sprintf("Hit %s", err.Error()))
 		return
 	} else if resp.StatusCode != http.StatusOK {
-		logger.Log(logger.WARN, "SERVER RETURNED STATUS " + http.StatusText(resp.StatusCode))
+		logger.Log(logger.WARN, "SERVER RETURNED STATUS "+http.StatusText(resp.StatusCode))
 		w.WriteHeader(resp.StatusCode)
 		return
 	}

--- a/proxy/GET.go
+++ b/proxy/GET.go
@@ -65,26 +65,59 @@ func GET(w http.ResponseWriter, url string, format string, token string, r *http
 
 	logger.LogResp(logger.DEBUG, res)
 
+	origin := r.Header.Get("Origin")
+
 	if err != nil {
+		// For an error in making the request
 		// Log the error, but return the output from the service.
-		invalidGET(w, err)
 		logger.Log(logger.ERR, err.Error())
+		processUnrecoverableErrors(w, http.StatusInternalServerError, "Error making the proxy request.")
 		return
 	} else if res.StatusCode == http.StatusFound {
+		// For redirects
 		logger.Log(logger.DEBUG, "Service Returned Redirect")
 		w.Header().Set("Location", res.Header.Get("Location"))
 		w.WriteHeader(http.StatusFound)
 		return
 	} else if res.StatusCode != http.StatusOK {
-		logger.Log(logger.WARN, "SERVICE RETURNED STATUS " + http.StatusText(res.StatusCode))
+		// For non-200 errors
+		contents, readErr := ioutil.ReadAll(res.Body)
+
+		if readErr != nil {
+			// 503 Bad Gateway, indicating a proxy / gateway recieved an invalid response from upstream server.
+			w.WriteHeader(http.StatusBadGateway)
+			w.Header().Set("Content-Type", TEXTHeader)
+			fmt.Fprintf(w, "%s\n", "The API Gateway sent an invalid response.")
+			return
+		}
+
+		logger.Log(logger.WARN, "SERVICE RETURNED STATUS "+http.StatusText(res.StatusCode))
+
 		w.WriteHeader(res.StatusCode)
-		return
+		switch {
+		case contains(JSONHeader, res.Header["Content-Type"]):
+			invalidJsonGET(w, contents, err)
+			return
+		case contains(XMLHeader, res.Header["Content-Type"]):
+			invalidXmlGET(w, contents, err)
+			return
+		default:
+			invalidTextGET(w, contents, err)
+			return
+		}
 	}
 
 	defer res.Body.Close()
-	contents, err := ioutil.ReadAll(res.Body)
 
-	origin := r.Header.Get("Origin")
+	contents, readErr := ioutil.ReadAll(res.Body)
+
+	if readErr != nil {
+		// 503 Bad Gateway, indicating a proxy / gateway recieved an invalid response from upstream server.
+		w.WriteHeader(http.StatusBadGateway)
+		w.Header().Set("Content-Type", TEXTHeader)
+		fmt.Fprintf(w, "%s\n", "The API Gateway sent an invalid response.")
+		return
+	}
 
 	//TODO: FIGURE OUT ORIGIN RULES
 	if origin != "" {
@@ -96,24 +129,24 @@ func GET(w http.ResponseWriter, url string, format string, token string, r *http
 	switch {
 	case contains(JSONHeader, res.Header["Content-Type"]):
 		jsonGET(w, url, contents)
-		break
+		return
 	case contains(TEXTHeader, res.Header["Content-Type"]):
 		textGET(w, url, contents)
-		break
+		return
 	case contains(HTMLHeader, res.Header["Content-Type"]):
 		textGET(w, url, contents)
-		break
+		return
 	case contains(XMLHeader, res.Header["Content-Type"]):
 		xmlGET(w, url, contents)
-		break
+		return
 	default:
 		if err != nil {
-			invalidGET(w, err)
+			invalidTextGET(w, contents, err)
 			logger.Log(logger.ERR, err.Error())
 			return
 		}
 		textGET(w, url, contents)
-		break
+		return
 	}
 }
 
@@ -121,7 +154,7 @@ func jsonGET(w http.ResponseWriter, url string, contents []byte) {
 	var data interface{}
 	err := json.Unmarshal(contents, &data)
 	if err != nil {
-		invalidGET(w, err)
+		invalidJsonGET(w, contents, err)
 		logger.Log(logger.ERR, err.Error())
 		return
 	}
@@ -129,7 +162,7 @@ func jsonGET(w http.ResponseWriter, url string, contents []byte) {
 	w.Header().Set("Content-Type", JSONHeader)
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(data); err != nil {
-		invalidGET(w, err)
+		invalidJsonGET(w, contents, err)
 		logger.Log(logger.ERR, err.Error())
 		return
 	}
@@ -139,7 +172,7 @@ func xmlGET(w http.ResponseWriter, url string, contents []byte) {
 	var data interface{}
 	err := xml.Unmarshal(contents, &data)
 	if err != nil {
-		invalidGET(w, err)
+		invalidXmlGET(w, contents, err)
 		logger.Log(logger.ERR, err.Error())
 		return
 	}
@@ -147,7 +180,7 @@ func xmlGET(w http.ResponseWriter, url string, contents []byte) {
 	w.Header().Set("Content-Type", XMLHeader)
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(data); err != nil {
-		invalidGET(w, err)
+		invalidXmlGET(w, contents, err)
 		logger.Log(logger.ERR, err.Error())
 		return
 	}
@@ -156,19 +189,47 @@ func xmlGET(w http.ResponseWriter, url string, contents []byte) {
 func textGET(w http.ResponseWriter, url string, contents []byte) {
 	var err error
 	if err != nil {
-		invalidGET(w, err)
+		invalidTextGET(w, contents, err)
 		logger.Log(logger.ERR, err.Error())
 		return
 	}
 	fmt.Fprintf(w, "%s\n", string(contents))
 }
 
-func invalidGET(w http.ResponseWriter, err error) {
-	// If we didn't find it, 404
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	w.WriteHeader(http.StatusNotFound)
-	data := map[string]interface{}{"Code": http.StatusNotFound, "Text": "Not Found", "server-err": err}
-	if err := json.NewEncoder(w).Encode(data); err != nil {
-		panic(err)
+func invalidJsonGET(w http.ResponseWriter, contents []byte, err error) {
+	w.Header().Set("Content-Type", JSONHeader)
+
+	var data interface{}
+	err = json.Unmarshal(contents, &data)
+
+	if err != nil {
+		processUnrecoverableErrors(w, http.StatusBadGateway, "The API Gateway sent an invalid response.")
+		return
 	}
+
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		processUnrecoverableErrors(w, http.StatusBadGateway, "The API Gateway sent an invalid response.")
+		return
+	}
+}
+
+func invalidXmlGET(w http.ResponseWriter, contents []byte, err error) {
+	w.Header().Set("Content-Type", XMLHeader)
+
+	var data interface{}
+	err = xml.Unmarshal(contents, &data)
+
+	if err != nil {
+		processUnrecoverableErrors(w, http.StatusBadGateway, "The API Gateway sent an invalid response.")
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		processUnrecoverableErrors(w, http.StatusBadGateway, "The API Gateway sent an invalid response.")
+		return
+	}
+}
+
+func invalidTextGET(w http.ResponseWriter, contents []byte, err error) {
+	w.Write(contents)
 }

--- a/proxy/GET.go
+++ b/proxy/GET.go
@@ -71,7 +71,7 @@ func GET(w http.ResponseWriter, url string, format string, token string, r *http
 		// For an error in making the request
 		// Log the error, but return the output from the service.
 		logger.Log(logger.ERR, err.Error())
-		processUnrecoverableErrors(w, http.StatusInternalServerError, "Error making the proxy request.")
+		notifyClientOfRequestError(w, http.StatusInternalServerError, "")
 		return
 	} else if res.StatusCode == http.StatusFound {
 		// For redirects
@@ -85,9 +85,7 @@ func GET(w http.ResponseWriter, url string, format string, token string, r *http
 
 		if readErr != nil {
 			// 503 Bad Gateway, indicating a proxy / gateway recieved an invalid response from upstream server.
-			w.WriteHeader(http.StatusBadGateway)
-			w.Header().Set("Content-Type", TEXTHeader)
-			fmt.Fprintf(w, "%s\n", "The API Gateway sent an invalid response.")
+			notifyClientOfRequestError(w, http.StatusBadGateway, "")
 			return
 		}
 
@@ -113,9 +111,7 @@ func GET(w http.ResponseWriter, url string, format string, token string, r *http
 
 	if readErr != nil {
 		// 503 Bad Gateway, indicating a proxy / gateway recieved an invalid response from upstream server.
-		w.WriteHeader(http.StatusBadGateway)
-		w.Header().Set("Content-Type", TEXTHeader)
-		fmt.Fprintf(w, "%s\n", "The API Gateway sent an invalid response.")
+		notifyClientOfRequestError(w, http.StatusBadGateway, "")
 		return
 	}
 
@@ -203,12 +199,12 @@ func invalidJsonGET(w http.ResponseWriter, contents []byte, err error) {
 	err = json.Unmarshal(contents, &data)
 
 	if err != nil {
-		processUnrecoverableErrors(w, http.StatusBadGateway, "The API Gateway sent an invalid response.")
+		notifyClientOfRequestError(w, http.StatusBadGateway, "")
 		return
 	}
 
 	if err := json.NewEncoder(w).Encode(data); err != nil {
-		processUnrecoverableErrors(w, http.StatusBadGateway, "The API Gateway sent an invalid response.")
+		notifyClientOfRequestError(w, http.StatusBadGateway, "")
 		return
 	}
 }
@@ -220,12 +216,12 @@ func invalidXmlGET(w http.ResponseWriter, contents []byte, err error) {
 	err = xml.Unmarshal(contents, &data)
 
 	if err != nil {
-		processUnrecoverableErrors(w, http.StatusBadGateway, "The API Gateway sent an invalid response.")
+		notifyClientOfRequestError(w, http.StatusBadGateway, "")
 		return
 	}
 
 	if err := json.NewEncoder(w).Encode(data); err != nil {
-		processUnrecoverableErrors(w, http.StatusBadGateway, "The API Gateway sent an invalid response.")
+		notifyClientOfRequestError(w, http.StatusBadGateway, "")
 		return
 	}
 }

--- a/proxy/PATCH.go
+++ b/proxy/PATCH.go
@@ -64,8 +64,8 @@ func PATCH(w http.ResponseWriter, url string, format string, token string, r *ht
 
 func invalidPATCH(w http.ResponseWriter, err error) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	w.WriteHeader(422) // unprocessable entity
-	data := map[string]interface{}{"Code": 400, "Text": "Unprocessable Entity", "Specfically": err}
+	w.WriteHeader(http.StatusUnprocessableEntity)
+	data := map[string]interface{}{"Code": http.StatusUnprocessableEntity, "Text": "Unprocessable Entity", "Specfically": err}
 	if err := json.NewEncoder(w).Encode(data); err != nil {
 		panic(err)
 	}

--- a/proxy/POST.go
+++ b/proxy/POST.go
@@ -215,8 +215,8 @@ func xmlPOST(r *http.Request, w http.ResponseWriter, url string, token string, c
 
 func invalidPOST(w http.ResponseWriter, err error) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	w.WriteHeader(422) // unprocessable entity
-	data := map[string]interface{}{"Code": 422, "Text": "Unprocessable Entity", "Specfically": err}
+	w.WriteHeader(http.StatusUnprocessableEntity)
+	data := map[string]interface{}{"Code": http.StatusUnprocessableEntity, "Text": "Unprocessable Entity", "Specfically": err}
 	if err := json.NewEncoder(w).Encode(data); err != nil {
 		panic(err)
 	}

--- a/proxy/PUT.go
+++ b/proxy/PUT.go
@@ -92,13 +92,36 @@ func PUT(w http.ResponseWriter, url string, format string, token string, r *http
 	}
 }
 
+// For PUT with actual processing errors.
+// For unsuccessful PUT requests, use unsuccessfulPUT
 func invalidPUT(w http.ResponseWriter, err error) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	w.WriteHeader(422) // unprocessable entity
+	w.WriteHeader(http.StatusUnprocessableEntity)
 	data := map[string]interface{}{"Code": 400, "Text": "Unprocessable Entity", "Specfically": err}
 	if err := json.NewEncoder(w).Encode(data); err != nil {
 		logger.Log(logger.ERR, err.Error())
-		panic(err) //ASK: SHOULD THIS BE HERE?
+		processUnrecoverableErrors(w, http.StatusBadGateway, "The API Gateway sent an invalid response.") //ASK: SHOULD THIS BE HERE?
+	}
+}
+
+// If the PUT was simply unsuccessful
+func unsuccessfulPUT(w http.ResponseWriter, format string, content []byte, err error) {
+	var data interface{}
+	switch format {
+	case "JSON":
+		json.Unmarshal(content, &data)
+		break
+	case "XML":
+		xml.Unmarshal(content, &data)
+		break
+	default:
+		// Text / HTML
+		w.Write(content)
+		return
+	}
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		logger.Log(logger.ERR, err.Error())
+		processUnrecoverableErrors(w, http.StatusBadGateway, "The API Gateway sent an invalid response.")
 	}
 }
 
@@ -140,8 +163,17 @@ func jsonPUT(r *http.Request, w http.ResponseWriter, url string, token string, d
 		return
 	} else if resp.StatusCode != http.StatusOK {
 		logger.Log(logger.WARN, "SERVICE FAILED - SERVICE RETURNED STATUS "+http.StatusText(resp.StatusCode))
+
 		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+
 		w.WriteHeader(resp.StatusCode)
+
+		content, readErr := ioutil.ReadAll(resp.Body)
+
+		api_format := "JSON"
+
+		unsuccessfulPUT(w, api_format, content, readErr)
+
 		return
 	}
 
@@ -206,8 +238,17 @@ func xmlPUT(r *http.Request, w http.ResponseWriter, url string, token string, da
 		return
 	} else if resp.StatusCode != http.StatusOK {
 		logger.Log(logger.WARN, "SERVICE FAILED - SERVICE RETURNED STATUS "+http.StatusText(resp.StatusCode))
+
 		w.Header().Set("Content-Type", XMLHeader)
+
 		w.WriteHeader(resp.StatusCode)
+
+		contents, readErr := ioutil.ReadAll(resp.Body)
+
+		api_format := "XML"
+
+		unsuccessfulPUT(w, api_format, contents, readErr)
+
 		return
 	}
 

--- a/proxy/PUT.go
+++ b/proxy/PUT.go
@@ -97,10 +97,10 @@ func PUT(w http.ResponseWriter, url string, format string, token string, r *http
 func invalidPUT(w http.ResponseWriter, err error) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusUnprocessableEntity)
-	data := map[string]interface{}{"Code": 400, "Text": "Unprocessable Entity", "Specfically": err}
+	data := map[string]interface{}{"Code": http.StatusUnprocessableEntity, "Text": "Unprocessable Entity", "Specfically": err}
 	if err := json.NewEncoder(w).Encode(data); err != nil {
 		logger.Log(logger.ERR, err.Error())
-		processUnrecoverableErrors(w, http.StatusBadGateway, "The API Gateway sent an invalid response.") //ASK: SHOULD THIS BE HERE?
+		notifyClientOfRequestError(w, http.StatusBadGateway, "") //ASK: SHOULD THIS BE HERE?
 	}
 }
 
@@ -121,7 +121,7 @@ func unsuccessfulPUT(w http.ResponseWriter, format string, content []byte, err e
 	}
 	if err := json.NewEncoder(w).Encode(data); err != nil {
 		logger.Log(logger.ERR, err.Error())
-		processUnrecoverableErrors(w, http.StatusBadGateway, "The API Gateway sent an invalid response.")
+		notifyClientOfRequestError(w, http.StatusBadGateway, "")
 	}
 }
 
@@ -170,9 +170,7 @@ func jsonPUT(r *http.Request, w http.ResponseWriter, url string, token string, d
 
 		content, readErr := ioutil.ReadAll(resp.Body)
 
-		api_format := "JSON"
-
-		unsuccessfulPUT(w, api_format, content, readErr)
+		unsuccessfulPUT(w, "JSON", content, readErr)
 
 		return
 	}
@@ -245,9 +243,7 @@ func xmlPUT(r *http.Request, w http.ResponseWriter, url string, token string, da
 
 		contents, readErr := ioutil.ReadAll(resp.Body)
 
-		api_format := "XML"
-
-		unsuccessfulPUT(w, api_format, contents, readErr)
+		unsuccessfulPUT(w, "XML", contents, readErr)
 
 		return
 	}

--- a/proxy/request_preprocessing.go
+++ b/proxy/request_preprocessing.go
@@ -50,3 +50,12 @@ func requestPreprocessing(w http.ResponseWriter, r *http.Request) error {
 	}
 	return nil
 }
+
+/*
+	Called if an error is casued while Marshalling / Unmarhsalling data, or making proxy requests.
+*/
+func processUnrecoverableErrors(w http.ResponseWriter, httpStatusCode int, message string) {
+	w.WriteHeader(httpStatusCode)
+	w.Header().Set("Content-Type", TEXTHeader)
+	fmt.Fprintf(w, "%s\n", message)
+}

--- a/server/router.go
+++ b/server/router.go
@@ -20,8 +20,8 @@ import (
 )
 
 func notFound(w http.ResponseWriter, r *http.Request) {
-	logRequest(r.Method, r.RequestURI, "UNKNOWN", 404, time.Duration(0))
-	w.WriteHeader(404)
+	logRequest(r.Method, r.RequestURI, "UNKNOWN", http.StatusNotFound, time.Duration(0))
+	w.WriteHeader(http.StatusNotFound)
 	io.WriteString(w, "404 Not Found")
 }
 


### PR DESCRIPTION
@bcongdon @narendasan 

Ensures that response body is sent even for non-200 requests. This addresses unsuccessful GET and PUT request issues on the microservices side.

If there are problems creating the request itself, such as with the format or data processing (conversion to and from JSON/XML etc.) it will revert to previous behavior of only logging the data but not sending it.

Addresses #50 

