### PR TITLE
Add Go Report Card badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/arbor-dev/arbor.svg?branch=master)](https://travis-ci.org/arbor-dev/arbor)
 [![GoDoc](https://godoc.org/github.com/arbor-dev/arbor?status.svg)](https://godoc.org/github.com/arbor-dev/arbor)
 [![Join the chat at https://acm-uiuc.slack.com/messages/C6XGZD212/](https://img.shields.io/badge/slack-groot-724D71.svg)](https://acm-uiuc.slack.com/messages/C6XGZD212/)
+[![Go Report Card](https://goreportcard.com/badge/github.com/arbor-dev/arbor)](https://goreportcard.com/report/github.com/arbor-dev/arbor)
 
 
 


### PR DESCRIPTION
Adds the Go Report Card badge to the README. This is useful to ensure that we're meeting Go's code-cleanliness standards
